### PR TITLE
Add Pokémon Forms Images to Gym/Raid Icons and Sidebar.

### DIFF
--- a/lib/Monocle_MAD.php
+++ b/lib/Monocle_MAD.php
@@ -386,7 +386,7 @@ class Monocle_MAD extends Monocle
         r.cp AS raid_pokemon_cp,
         r.move_1 AS raid_pokemon_move_1,
         r.move_2 AS raid_pokemon_move_2,
-        r.form
+        r.form AS raid_pokemon_form
         FROM forts f
         LEFT JOIN fort_sightings fs ON fs.fort_id = f.id
         LEFT JOIN raids r ON r.fort_id = f.id
@@ -413,6 +413,7 @@ class Monocle_MAD extends Monocle
             $gym["pokemon"] = [];
             $gym["guard_pokemon_name"] = empty($guard_pid) ? null : i8ln($this->data[$guard_pid]["name"]);
             $gym["raid_pokemon_name"] = empty($raid_pid) ? null : i8ln($this->data[$raid_pid]["name"]);
+            $gym["form"] = intval($gym["raid_pokemon_form"]);
             $gym["latitude"] = floatval($gym["latitude"]);
             $gym["longitude"] = floatval($gym["longitude"]);
             $gym["sponsor"] = intval($gym["sponsor"]);

--- a/lib/Monocle_PMSF.php
+++ b/lib/Monocle_PMSF.php
@@ -351,7 +351,7 @@ class Monocle_PMSF extends Monocle
         r.cp AS raid_pokemon_cp,
         r.move_1 AS raid_pokemon_move_1,
         r.move_2 AS raid_pokemon_move_2,
-        r.form
+        r.form AS raid_pokemon_form
         FROM forts f
         LEFT JOIN fort_sightings fs ON fs.fort_id = f.id
         LEFT JOIN raids r ON r.fort_id = f.id
@@ -378,6 +378,7 @@ class Monocle_PMSF extends Monocle
             $gym["pokemon"] = [];
             $gym["guard_pokemon_name"] = empty($guard_pid) ? null : i8ln($this->data[$guard_pid]["name"]);
             $gym["raid_pokemon_name"] = empty($raid_pid) ? null : i8ln($this->data[$raid_pid]["name"]);
+            $gym["form"] = intval($gym["raid_pokemon_form"]);
             $gym["latitude"] = floatval($gym["latitude"]);
             $gym["longitude"] = floatval($gym["longitude"]);
             $gym["sponsor"] = intval($gym["sponsor"]);

--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -363,7 +363,7 @@ class RDM extends Scanner
         raid_level,
         raid_pokemon_move_1,
         raid_pokemon_move_2,
-        raid_pokemon_form AS raid_pokemon_form,
+        raid_pokemon_form,
         raid_pokemon_cp,
         ex_raid_eligible AS park
         FROM gym

--- a/lib/RDM.php
+++ b/lib/RDM.php
@@ -363,7 +363,7 @@ class RDM extends Scanner
         raid_level,
         raid_pokemon_move_1,
         raid_pokemon_move_2,
-        raid_pokemon_form AS form,
+        raid_pokemon_form AS raid_pokemon_form,
         raid_pokemon_cp,
         ex_raid_eligible AS park
         FROM gym
@@ -390,6 +390,7 @@ class RDM extends Scanner
             $gym["pokemon"] = [];
             $gym["guard_pokemon_name"] = empty($guard_pid) ? null : i8ln($this->data[$guard_pid]["name"]);
             $gym["raid_pokemon_name"] = empty($raid_pid) ? null : i8ln($this->data[$raid_pid]["name"]);
+            $gym["form"] = intval($gym["raid_pokemon_form"]);
             $gym["latitude"] = floatval($gym["latitude"]);
             $gym["longitude"] = floatval($gym["longitude"]);
             //$gym["sponsor"] = intval($gym["sponsor"]);

--- a/lib/RocketMap_MAD.php
+++ b/lib/RocketMap_MAD.php
@@ -105,7 +105,8 @@ class RocketMap_MAD extends RocketMap
         url,
         is_ex_raid_eligible AS park,
         level AS raid_level, 
-        pokemon_id AS raid_pokemon_id, 
+        raid.pokemon_id AS raid_pokemon_id, 
+        raid.form AS raid_pokemon_form, 
         cp AS raid_pokemon_cp, 
         move_1 AS raid_pokemon_move_1, 
         move_2 AS raid_pokemon_move_2, 
@@ -139,6 +140,7 @@ class RocketMap_MAD extends RocketMap
             $gym["pokemon"] = [];
             $gym["guard_pokemon_name"] = empty($guard_pid) ? null : i8ln($this->data[$guard_pid]["name"]);
             $gym["raid_pokemon_name"] = empty($raid_pid) ? null : i8ln($this->data[$raid_pid]["name"]);
+            $gym["form"] = intval($gym["raid_pokemon_form"]);
             $gym["latitude"] = floatval($gym["latitude"]);
             $gym["longitude"] = floatval($gym["longitude"]);
             $gym["last_modified"] = $gym["last_modified"] * 1000;


### PR DESCRIPTION
The frontend map.js was already looking for the information in this element's name (`var raidForm = item['form']`) so this PR simply fills it with the proper value when the database is queried and no changes to map.js are required.

It is the same fix I have been using in my fork but cleaned up without unnecessary changes and should work with all supported backend variants reusing the information and queries available in the latest develop branch.

NOTE: This does NOT add form images to the reward searches which will be handled in a separate PR.